### PR TITLE
Refactor and rename internal functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Description: Casts (R)Markdown files to XML and back to allow their editing via 
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1.9000
+RoxygenNote: 7.1.1.9001
 Imports: 
     magrittr,
     commonmark (>= 1.6),

--- a/R/asis-nodes.R
+++ b/R/asis-nodes.R
@@ -109,7 +109,7 @@ protect_inline_math <- function(body, ns) {
   if (length(imath)) {
     new_nodes <- lapply(
       fix_fully_inline(imath), 
-      FUN = function(n) xml2::xml_ns_strip(xml2::xml_children(n))
+      FUN = function(n) xml2::xml_children(n)
     )
     # since we split up the nodes, we have to do this node by node
     for (i in seq(new_nodes)) {
@@ -159,7 +159,6 @@ fix_partial_inline <- function(tag, body, ns) {
   char[[n]] <- sub("[<]text ", "<text asis='true' ", char[[n]])
   nodes <- paste(char, collapse = "")
   nodes <- xml2::xml_children(make_text_nodes(nodes))
-  nodes <- xml2::xml_ns_strip(nodes)
   # add the new nodes to the bottom of the existing math lines 
   last_line <- math_lines[n]
   to_remove <- math_lines[-n]
@@ -185,7 +184,7 @@ fix_fully_inline <- function(math) {
 
 make_text_nodes <- function(txt) {
   doc <- glue::glue(commonmark::markdown_xml("{paste(txt, collapse = '\n')}")) 
-  doc <- xml2::read_xml(doc)
+  doc <- xml2::xml_ns_strip(xml2::read_xml(doc))
   nodes <- xml2::xml_children(xml2::xml_children(doc))
   nodes[xml2::xml_name(nodes) != "softbreak"]
 }
@@ -229,7 +228,7 @@ protect_tickbox <- function(body, ns) {
   char <- sub("(\\[.\\])", "\\1</text><text>", char, perl = TRUE)
   new_nodes <- lapply(
     make_text_nodes(char), 
-    function(n) xml2::xml_ns_strip(xml2::xml_children(n))
+    function(n) xml2::xml_children(n)
   )
   # since we split up the nodes, we have to do this node by node
   for (i in seq(new_nodes)) {

--- a/R/asis-nodes.R
+++ b/R/asis-nodes.R
@@ -184,14 +184,11 @@ fix_fully_inline <- function(math) {
 }
 
 set_default_space <- function(char) {
-  new_nodes <- char_to_nodelist(char)
-  n <- xml2::xml_find_all(new_nodes, ".//node()")
-  # set space to default to avoid weird formatting (this may change)
-  xml2::xml_set_attr(n, "xml:space", "default")
+  new_nodes <- make_text_nodes(char)
   new_nodes
 }
 
-char_to_nodelist <- function(txt) {
+make_text_nodes <- function(txt) {
   doc <- glue::glue(commonmark::markdown_xml("{paste(txt, collapse = '\n')}")) 
   doc <- xml2::read_xml(doc)
   nodes <- xml2::xml_children(xml2::xml_children(doc))

--- a/R/asis-nodes.R
+++ b/R/asis-nodes.R
@@ -158,7 +158,7 @@ fix_partial_inline <- function(tag, body, ns) {
   char[[1]] <- sub("[$]", "$</text><text asis='true'>", char[[1]])
   char[[n]] <- sub("[<]text ", "<text asis='true' ", char[[n]])
   nodes <- paste(char, collapse = "")
-  nodes <- xml2::xml_children(set_default_space(nodes))
+  nodes <- xml2::xml_children(make_text_nodes(nodes))
   nodes <- xml2::xml_ns_strip(nodes)
   # add the new nodes to the bottom of the existing math lines 
   last_line <- math_lines[n]
@@ -180,12 +180,7 @@ fix_fully_inline <- function(math) {
     x = char,
     perl = TRUE
   )
-  set_default_space(char)
-}
-
-set_default_space <- function(char) {
-  new_nodes <- make_text_nodes(char)
-  new_nodes
+  make_text_nodes(char)
 }
 
 make_text_nodes <- function(txt) {
@@ -233,7 +228,7 @@ protect_tickbox <- function(body, ns) {
   char <- as.character(ticks)
   char <- sub("(\\[.\\])", "\\1</text><text>", char, perl = TRUE)
   new_nodes <- lapply(
-    set_default_space(char), 
+    make_text_nodes(char), 
     function(n) xml2::xml_ns_strip(xml2::xml_children(n))
   )
   # since we split up the nodes, we have to do this node by node


### PR DESCRIPTION
This takes the unweildy and unhelpful pair of `set_default_space()` and `char_to_nodelist()` and renames them to `make_text_nodes()`, simplifying and refactoring much of the code along the way.