### PR TITLE
Clean newly created anchor links

### DIFF
--- a/R/resolve-links.R
+++ b/R/resolve-links.R
@@ -174,7 +174,10 @@ al_name <- function(link) {
 }
 
 al_dest <- function(link) {
-  sub("^[\\[].+?[\\]]:\\s([^\\s]+?)(\\s['\"]?.*?)?$", "\\1", link, perl = TRUE)
+  res <- sub("^[\\[].+?[\\]]:\\s([^\\s]+?)(\\s['\"]?.*?)?$", "\\1", link, perl = TRUE)
+  # escape ampersands that are not valid code points, though this will still
+  # allow invalid code points, but it's better than nothing
+  gsub("[&](?![#]?[A-Za-z0-9]+?[;])", "&amp;", res, perl = TRUE)
 }
 
 al_title <- function(link) {

--- a/R/resolve-links.R
+++ b/R/resolve-links.R
@@ -169,15 +169,21 @@ build_anchor_links <- function(link) {
 # Helpers for parsing anchor links:
 #
 #   [name]: dest 'title'
+
+escape_ampersand <- function(amp) {
+  # escape ampersands that are not valid code points, though this will still
+  # allow invalid code points, but it's better than nothing
+  gsub("[&](?![#]?[A-Za-z0-9]+?[;])", "&amp;", amp, perl = TRUE)
+}
+
 al_name <- function(link) {
-  sub("^[[\\[](.+?)[\\]]:\\s.+?$", "\\1", link, perl = TRUE)
+  res <- sub("^[[\\[](.+?)[\\]]:\\s.+?$", "\\1", link, perl = TRUE)
+  escape_ampersand(res)
 }
 
 al_dest <- function(link) {
   res <- sub("^[\\[].+?[\\]]:\\s([^\\s]+?)(\\s['\"]?.*?)?$", "\\1", link, perl = TRUE)
-  # escape ampersands that are not valid code points, though this will still
-  # allow invalid code points, but it's better than nothing
-  gsub("[&](?![#]?[A-Za-z0-9]+?[;])", "&amp;", res, perl = TRUE)
+  escape_ampersand(res)
 }
 
 al_title <- function(link) {
@@ -186,7 +192,7 @@ al_title <- function(link) {
   titles <- sub("^[\\[].+?[\\]]:\\s[^\\s]+?(\\s['\"](.*?)['\"])$", "\\2", 
     link, perl = TRUE)
   titles[titles == link] <- ""
-  titles
+  escape_ampersand(titles)
 }
 
 #nocov start

--- a/inst/extdata/link-test.md
+++ b/inst/extdata/link-test.md
@@ -18,6 +18,8 @@ This should also [include non-reference links](https://example.com/5)
 If you write \[some link text\]\[link2\], that will appear as [some link text][link2]
 but you can also [test][racehorse] [sub][sub-link1] [links][sub-link2]
 
+[pizza & icecream][pizzaicecream] = fun
+
 ```markdown
 you can write links like [a link](https://example.com/racehorse) or using
 [reference style][racehorce]
@@ -33,6 +35,7 @@ you can write links like [a link](https://example.com/racehorse) or using
 [racehorse]: https://example.com/racehorse/   
 [sub-link1]: https://example.com/racehorse/1/1 "One One Won One"
 [sub-link2]: https://example.com/racehorse/2/2/ "Two Two Won One Two"
+[pizzaicecream]: https://example.com/pizza&icecream
 
 ## This is some extended markdown content {#extended .callout}
 

--- a/tests/testthat/_snaps/anchor-links.md
+++ b/tests/testthat/_snaps/anchor-links.md
@@ -22,6 +22,8 @@
       If you write \[some link text\]\[link2\], that will appear as [some link text][link2]
       but you can also [test][racehorse] [sub][sub-link1] [links][sub-link2]
       
+      [pizza \& icecream][pizzaicecream] = fun
+      
       ```markdown
       you can write links like [a link](https://example.com/racehorse) or using
       [reference style][racehorce]
@@ -48,6 +50,7 @@
       [racehorse]: https://example.com/racehorse/
       [sub-link1]: https://example.com/racehorse/1/1 "One One Won One"
       [sub-link2]: https://example.com/racehorse/2/2/ "Two Two Won One Two"
+      [pizzaicecream]: https://example.com/pizza&icecream
       [standalone]: https://example.com/standalone
       
       
@@ -75,6 +78,8 @@
       
       If you write \[some link text\]\[link2\], that will appear as [some link text](https://example.com/2 "link with title!")
       but you can also [test](https://example.com/racehorse/) [sub](https://example.com/racehorse/1/1 "One One Won One") [links](https://example.com/racehorse/2/2/ "Two Two Won One Two")
+      
+      [pizza \& icecream](https://example.com/pizza&icecream) = fun
       
       ```markdown
       you can write links like [a link](https://example.com/racehorse) or using


### PR DESCRIPTION
I ran into a situation where I had this anchor link: `https://www.worldcat.org/search?q=au%3ABenner%2C+Patricia+E.&qt=hot_author`, which XML did not like because  of the `&`. 

This protects the bare ampersands according to https://lachy.id.au/log/2005/10/char-refs by replacing them with `&amp;`