### PR TITLE
Fix 53

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 * 2021-05-24: reference style links (i.e. `[text][link-ref]` with `[link-ref]: 
   <link>` on another place in the document will be preserved and the anchor will
   sink to the bottom of the document.
+* 2021-09-14: numeric options fig.width and fig.height will no longer be quoted;
+  `transform_params()` is simplified and no longer requires glue.
 
 # tinkr 0.0.0.9000
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -62,7 +62,7 @@ transform_params <- function(params) {
   # Step 1: parse the parameters and their labels into a list
   params_list <- try(parse_params(params), silent = TRUE)
 
-  if (inherits(params_list, "try-error")){
+  if (inherits(params_list, "try-error")) {
     params <- stringr::str_replace(params, " ", ", ")
     params_list <- parse_params(params)
   }
@@ -79,7 +79,7 @@ transform_params <- function(params) {
 
   # Step 4: add quotes around the params that are characters
   not_forbidden <- !names(result) %in% c("language", "name")
-  needs_quoting  <- are_characters & not_forbidden
+  needs_quoting <- are_characters & not_forbidden
   result[needs_quoting] <- shQuote(result[needs_quoting], type = "cmd")
 
   result

--- a/R/utils.R
+++ b/R/utils.R
@@ -61,7 +61,7 @@ transform_params <- function(params){
   params_string <- try(eval(parse(text = paste('alist(', quote_label(params), ')'))),
                        silent = TRUE)
 
-  if(inherits(params_string, "try-error")){
+  if (inherits(params_string, "try-error")){
     params <- stringr::str_replace(params, " ", ", ")
     params_string <- eval(parse(text = paste('alist(', quote_label(params), ')')))
   }
@@ -69,25 +69,19 @@ transform_params <- function(params){
   label <- parse_label(params_string[[1]])
 
   result <- unlist(c(label, params_string[-1]))
-  result[purrr::map_lgl(result, is.character)&
-           !names(result) %in% c("language", "name")] <- glue::glue('"{result[purrr::map_lgl(result, is.character)&
-           !names(result) %in% c("language", "name")]}"')
 
-  logical_options <- c("echo", "eval", "collapse", "warning",
+  logical_options  <- c("echo", "eval", "collapse", "warning",
                        "error", "message", "split", "include",
                        "strip.white", "prompt", "highlight", "cache",
                        "autodep", "external", "sanitize", "purl")
-  if(any(names(result) %in% logical_options)){
+  unquoted_options <- c("language", "name", "fig.width", "fig.height")
 
-    result[names(result) %in% logical_options&
-             is.character(result)] <- stringr::str_remove_all(result[names(result) %in% logical_options&
-                                                                       is.character(result)],
-                                                                          "\\\"")
+  are_characters <- purrr::map_lgl(result, is.character)
+  not_forbidden  <- !names(result) %in% c(unquoted_options, logical_options)
+  needs_quoting  <- are_characters & not_forbidden
+  result[needs_quoting] <- shQuote(result[needs_quoting], type = "cmd")
 
-
-  }
-
-   result
+  result
 }
 
 

--- a/tests/testthat/test-to_xml.R
+++ b/tests/testthat/test-to_xml.R
@@ -39,12 +39,13 @@ test_that("to_xml will not convert numeric options to character", {
 
 test_that("to_xml will not convert chunk options as r objects to character", {
 
-  txt <- "```{r txt, R.options = list(width = 100)}\n#code\n```"
+  txt <- "```{r txt, R.options = list(width = 100), eval = eval_param}\n#code\n```"
   con <- textConnection(txt)
   code <- xml2::xml_find_first(to_xml(con)$body, "d1:code_block")
   attrs <- xml2::xml_attrs(code)
   expect_equal(attrs[["name"]], "txt")
   expect_equal(attrs[["R.options"]], "list(width = 100)")
+  expect_equal(attrs[["eval"]], "eval_param")
 
 })
 

--- a/tests/testthat/test-to_xml.R
+++ b/tests/testthat/test-to_xml.R
@@ -24,10 +24,16 @@ test_that("to_xml works for Rmd", {
 
 
 test_that("to_xml will not convert numeric options to character", {
-  txt <- "```{r txt, fig.width=4.2, fig.height=4.2, out.width='100%', eval = FALSE}\n#code\n```"
+  txt <- "```{r txt, fig.width=4.2, fig.height=4.2, out.width='100%', purl = TRUE}\n#code\n```"
   con <- textConnection(txt)
   code <- xml2::xml_find_first(to_xml(con)$body, "d1:code_block")
-  expect_equal(xml2::xml_attr(code), list(name = "txt", fig.width = "4.2", fig.height = "4.2", out.width = "\"100%\"", eval = "FALSE"))
+  attrs <- xml2::xml_attrs(code)
+  expect_equal(attrs[["fig.width"]], "4.2") 
+  expect_equal(attrs[["fig.height"]], "4.2") 
+  # out.width is the only one that's quoted
+  expect_equal(attrs[["out.width"]], shQuote("100%", type = "cmd"))
+  expect_equal(attrs[["purl"]], "TRUE")
+  expect_equal(attrs[["name"]], "txt")
 })
 
 

--- a/tests/testthat/test-to_xml.R
+++ b/tests/testthat/test-to_xml.R
@@ -22,6 +22,15 @@ test_that("to_xml works for Rmd", {
 
 })
 
+
+test_that("to_xml will not convert numeric options to character", {
+  txt <- "```{r txt, fig.width=4.2, fig.height=4.2, out.width='100%', eval = FALSE}\n#code\n```"
+  con <- textConnection(txt)
+  code <- xml2::xml_find_first(to_xml(con)$body, "d1:code_block")
+  expect_equal(xml2::xml_attr(code), list(name = "txt", fig.width = "4.2", fig.height = "4.2", out.width = "\"100%\"", eval = "FALSE"))
+})
+
+
 test_that("to_xml works with text connection", {
 
   path <- system.file("extdata", "example2.Rmd", package = "tinkr")

--- a/tests/testthat/test-to_xml.R
+++ b/tests/testthat/test-to_xml.R
@@ -37,6 +37,30 @@ test_that("to_xml will not convert numeric options to character", {
 })
 
 
+test_that("to_xml will not convert chunk options as r objects to character", {
+
+  txt <- "```{r txt, R.options = list(width = 100)}\n#code\n```"
+  con <- textConnection(txt)
+  code <- xml2::xml_find_first(to_xml(con)$body, "d1:code_block")
+  attrs <- xml2::xml_attrs(code)
+  expect_equal(attrs[["name"]], "txt")
+  expect_equal(attrs[["R.options"]], "list(width = 100)")
+
+})
+
+test_that("to_xml will respect logicals for custom chunk options", {
+
+  txt <- "```{r txt, coffee = TRUE, tea = FALSE, fun = 'pizza+icecream'}\n#code\n```"
+  con <- textConnection(txt)
+  code <- xml2::xml_find_first(to_xml(con)$body, "d1:code_block")
+  attrs <- xml2::xml_attrs(code)
+  expect_equal(attrs[["name"]], "txt")
+  expect_equal(attrs[["coffee"]], "TRUE")
+  expect_equal(attrs[["tea"]], "FALSE")
+  expect_equal(attrs[["fun"]], shQuote("pizza+icecream", type = "cmd"))
+
+})
+
 test_that("to_xml works with text connection", {
 
   path <- system.file("extdata", "example2.Rmd", package = "tinkr")


### PR DESCRIPTION
I've modified `transform_params()` in the following ways:

1. assigned the subsetting statements to descriptive names
2. disallowed logical params from being quoted in the first place
3. protected fig.width and fig.height from being quoted
4. replaced the {glue} statement with the equivalent `shQuote(var, type = "cmd")`

reprex:

``` r
library(tinkr)
f <- tempfile()
writeLines("```{r ggplot, fig.width=4.2}\n# code here\n```", f)
yarn$new(f)$show()
#> ```{r ggplot, fig.width=4.2}
#> # code here
#> ```
```

<sup>Created on 2021-09-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

This will fix #53