### PR TITLE
add tasklist template for commonmark 1.8

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^README\.Rmd$
 .ropensci-staff
 ^inst/presub\.md$
+^_pkgdown.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tinkr
 Title: Cast (R)Markdown Files to XML and Back Again
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 Authors@R: 
     c(person(given = "Maëlle",
              family = "Salmon",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
-# tinkr dev
+# tinkr 0.0.0.9002
+
+## BUG FIX
+
+* 2022-03-23: added `tasklist` template for compatibility with commonmark
+  version 1.8 (#66)
+
+# tinkr 0.0.0.9001
 
 * xml and yaml objects are now stored in an R6 class called `yarn`.
 * testthat edition 3 is now being used with snapshot testing.

--- a/R/to_xml.R
+++ b/R/to_xml.R
@@ -45,7 +45,11 @@ to_xml <- function(path, encoding = "UTF-8", sourcepos = FALSE, anchor_links = T
     xml2::read_xml(encoding = encoding) -> body
 
   parse_rmd(body)
-  body <- protect_tickbox(body, md_ns())
+  if (utils::packageVersion("commonmark") < "1.8.0") {
+    #nocov start
+    body <- protect_tickbox(body, md_ns())
+    #nocov end
+  }
   if (anchor_links) {
     body <- resolve_anchor_links(body, splitted_content$body) 
   }

--- a/inst/extdata/xml2md_gfm.xsl
+++ b/inst/extdata/xml2md_gfm.xsl
@@ -62,22 +62,35 @@
     <xsl:text>&#10;</xsl:text>
     </xsl:template>
 
+    <xsl:template match="md:tasklist">
+      <xsl:apply-templates select="." mode="indent-block"/>
+      <xsl:choose>
+        <xsl:when test="@completed = 'true'">- [x]</xsl:when>
+        <xsl:when test="@completed = 'false'">- [ ]</xsl:when>
+      </xsl:choose>
+      <xsl:text> </xsl:text>
+      <xsl:apply-templates select="md:*"/>
+    </xsl:template>
+
+    <xsl:template match="md:item" mode="indent">
+      <xsl:text>  </xsl:text>
+    </xsl:template>
 
 
     <!-- Table -->
 
     <xsl:template match="md:table">
-        <xsl:apply-templates select="." mode="indent-block"/>
-        <xsl:apply-templates select="md:*"/>
+      <xsl:apply-templates select="." mode="indent-block"/>
+      <xsl:apply-templates select="md:*"/>
     </xsl:template>
 
     <xsl:variable name="minLength">3</xsl:variable>
 
     <xsl:variable name="maxLength">
-        <xsl:for-each select="//md:table_header/md:table_cell">
-            <xsl:variable name="pos" select="position()"/>
-            <!-- EXslt or XSLT 1.1 would be needed to lookup node-sets;
-                thus generating a string (something like CELL1:7|CELL2:5|CELL3:9|CELL4:8|) -->
+      <xsl:for-each select="//md:table_header/md:table_cell">
+        <xsl:variable name="pos" select="position()"/>
+          <!-- EXslt or XSLT 1.1 would be needed to lookup node-sets;
+          thus generating a string (something like CELL1:7|CELL2:5|CELL3:9|CELL4:8|) -->
             <xsl:text>CELL</xsl:text>
             <xsl:value-of select="$pos"/>
             <xsl:text>:</xsl:text>


### PR DESCRIPTION
The commonmark spec updated to include tasklists
https://github.github.com/gfm/#task-list-items-extension-

This was implemented in commonmark 1.8 with
https://github.com/r-lib/commonmark/pull/18. This PR should be
backwards compatible with older versions of commonmark

This will fix #66

