### PR TITLE
don't escape relative link anchors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
   unescaped square braces to remain unescaped (#78). 
 * New `protect_curly()` function will add a `curly='true'` attribute to text wrapped in curly braces ('{', '}') to allow parsing of the XML for sending to external APIs. This function will also parse alt text and place it in an attribute.
 * New `$protect_curly()` method implements `protect_curly()` on yarn objects
-* relative link anchor keys will no longer have characters escaped (#85)
+* Relative link anchor keys will no longer have characters escaped (#85).
 
 # tinkr 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
   unescaped square braces to remain unescaped (#78). 
 * New `protect_curly()` function will add a `curly='true'` attribute to text wrapped in curly braces ('{', '}') to allow parsing of the XML for sending to external APIs. This function will also parse alt text and place it in an attribute.
 * New `$protect_curly()` method implements `protect_curly()` on yarn objects
+* relative link anchor keys will no longer have characters escaped (#85)
 
 # tinkr 0.1.0
 

--- a/inst/extdata/link-test.md
+++ b/inst/extdata/link-test.md
@@ -16,7 +16,7 @@ by reference][link4] and if links [can be referenced multiple times][this fun li
 This should also [include non-reference links](https://example.com/5)
 
 If you [write]{.confession} \[some link text\]\[link2\], that will appear as [some link text][link2]
-but you can also [test][racehorse] [sub][sub-link1] [links][sub-link2]
+but you can also [test][racehorse] [sub][sub-link1] [links][sub_link2]
 
 [pizza & icecream][pizzaicecream] = fun
 
@@ -34,7 +34,7 @@ you can write links like [a link](https://example.com/racehorse) or using
 [link4]: https://example.com/4
 [racehorse]: https://example.com/racehorse/   
 [sub-link1]: https://example.com/racehorse/1/1 "One One Won One"
-[sub-link2]: https://example.com/racehorse/2/2/ "Two Two Won One Two"
+[sub_link2]: https://example.com/racehorse/2/2/ "Two Two Won One Two"
 [pizzaicecream]: https://example.com/pizza&icecream
 
 ## This is some extended markdown content {#extended .callout}

--- a/inst/stylesheets/xml2md_gfm.xsl
+++ b/inst/stylesheets/xml2md_gfm.xsl
@@ -45,7 +45,7 @@
     <xsl:template match="md:link[@anchor]">
       <xsl:if test="self::md:image">!</xsl:if>
       <xsl:text>[</xsl:text>
-      <xsl:apply-templates select="md:*"/>
+      <xsl:value-of select='string(.)'/>
       <xsl:text>]: </xsl:text>
       <xsl:call-template name="escape-text">
           <xsl:with-param name="text" select="string(@destination)"/>

--- a/inst/stylesheets/xml2md_gfm.xsl
+++ b/inst/stylesheets/xml2md_gfm.xsl
@@ -43,23 +43,23 @@
     </xsl:template>
 
     <xsl:template match="md:link[@anchor]">
-    <xsl:if test="self::md:image">!</xsl:if>
-    <xsl:text>[</xsl:text>
-    <xsl:apply-templates select="md:*"/>
-    <xsl:text>]: </xsl:text>
-    <xsl:call-template name="escape-text">
-        <xsl:with-param name="text" select="string(@destination)"/>
-        <xsl:with-param name="escape" select="'()'"/>
-    </xsl:call-template>
-    <xsl:if test="string(@title)">
-        <xsl:text> "</xsl:text>
-        <xsl:call-template name="escape-text">
-            <xsl:with-param name="text" select="string(@title)"/>
-            <xsl:with-param name="escape" select="'&quot;'"/>
-        </xsl:call-template>
-        <xsl:text>"</xsl:text>
-    </xsl:if>
-    <xsl:text>&#10;</xsl:text>
+      <xsl:if test="self::md:image">!</xsl:if>
+      <xsl:text>[</xsl:text>
+      <xsl:apply-templates select="md:*"/>
+      <xsl:text>]: </xsl:text>
+      <xsl:call-template name="escape-text">
+          <xsl:with-param name="text" select="string(@destination)"/>
+          <xsl:with-param name="escape" select="'()'"/>
+      </xsl:call-template>
+      <xsl:if test="string(@title)">
+          <xsl:text> "</xsl:text>
+          <xsl:call-template name="escape-text">
+              <xsl:with-param name="text" select="string(@title)"/>
+              <xsl:with-param name="escape" select="'&quot;'"/>
+          </xsl:call-template>
+          <xsl:text>"</xsl:text>
+      </xsl:if>
+      <xsl:text>&#10;</xsl:text>
     </xsl:template>
 
     <xsl:template match="md:tasklist">

--- a/tests/testthat/_snaps/anchor-links.md
+++ b/tests/testthat/_snaps/anchor-links.md
@@ -20,7 +20,7 @@
       This should also [include non-reference links](https://example.com/5)
       
       If you [write]{.confession} \[some link text\]\[link2\], that will appear as [some link text][link2]
-      but you can also [test][racehorse] [sub][sub-link1] [links][sub-link2]
+      but you can also [test][racehorse] [sub][sub-link1] [links][sub_link2]
       
       [pizza \& icecream][pizzaicecream] = fun
       
@@ -49,7 +49,7 @@
       [link2]: https://example.com/2 "link with title!"
       [racehorse]: https://example.com/racehorse/
       [sub-link1]: https://example.com/racehorse/1/1 "One One Won One"
-      [sub-link2]: https://example.com/racehorse/2/2/ "Two Two Won One Two"
+      [sub_link2]: https://example.com/racehorse/2/2/ "Two Two Won One Two"
       [pizzaicecream]: https://example.com/pizza&icecream
       [standalone]: https://example.com/standalone
       


### PR DESCRIPTION
This will address #85 by not escaping relative link anchors if they have escapable characters.

Since these are not rendred by markdown to HTML, there is no reason to escape them, thus this pattern will now work:

```markdown
here is a [linke that we use an underscore in][underscored_link]. It will not
be escaped when we roundtrip with {tinkr}!

[underscored_link]: https://github.com/ropensci/tinkr/issues/85
```
