### PR TITLE
If no yaml, avoid prepending with gratuitous `\n`

### DIFF
--- a/R/to_md.R
+++ b/R/to_md.R
@@ -61,7 +61,9 @@ to_md <- function(yaml_xml_list, path = NULL, stylesheet_path = stylesheet()){
 transform_to_md <- function(body, yaml, stylesheet) {
   body <- xslt::xml_xslt(body, stylesheet = stylesheet)
 
-  yaml <- glue::glue_collapse(yaml, sep = "\n")
+  if (length(yaml) > 0) {
+    yaml <- glue::glue_collapse(yaml, sep = "\n")
+  }
 
   c(yaml, body)
 }


### PR DESCRIPTION
This PR adapts tinkr for forward compatibility with glue. I will release glue no sooner than 2 weeks from now, so on March 31 (or likely a bit later).

In the next version of glue, `glue::glue_collapse()` will never return `character()` but instead will return `""` for empty inputs. For more detail see https://github.com/tidyverse/glue/pull/295.

In my hands, this PR makes tinkr work as intended with released glue and dev glue.
