### PR TITLE
Footnotes should not be escaped

### DIFF
--- a/tests/testthat/_snaps/anchor-links.md
+++ b/tests/testthat/_snaps/anchor-links.md
@@ -101,3 +101,17 @@
       should be preserved
       
 
+# footnotes square brackets are not escaped
+
+    Code
+      cat(tinkr::yarn$new(temp_file, anchor_links = TRUE)$head())
+    Output
+      something\[^1\] nice anything\[^ouch\] good  \[^1\]: a thing \[^ouch\]: another thing 
+
+---
+
+    Code
+      cat(tinkr::yarn$new(temp_file, anchor_links = FALSE)$head())
+    Output
+      something\[^1\] nice anything\[^ouch\] good  \[^1\]: a thing \[^ouch\]: another thing 
+

--- a/tests/testthat/test-anchor-links.R
+++ b/tests/testthat/test-anchor-links.R
@@ -11,7 +11,7 @@ test_that("anchor links with duplicate id and text are not doubled", {
   res <- tinkr::yarn$new(temp_file)$show()
   expect_equal(res[res != ""], lines[lines != ""])
   #> [thing] lala[^1] blabla
-  #> 
+  #>
   #> [thing]: what
   #> [^1]: pof
 
@@ -29,7 +29,7 @@ test_that("users can turn off anchor links", {
 })
 
 test_that("links can go round trip", {
-  
+
   m <- yarn$new(f)
   tmp <- withr::local_tempfile()
   m$write(tmp)
@@ -39,7 +39,7 @@ test_that("links can go round trip", {
 })
 
 test_that("singluar nodes can be added to the body", {
-  
+
   m <- yarn$new(f)
   node1 <- build_anchor_links("[a]: b 'c'")[[1]]
   node2 <- build_anchor_links("[A]: B 'C'")[[1]]
@@ -57,5 +57,17 @@ test_that("singluar nodes can be added to the body", {
   buddy_node2 <- xml2::xml_find_all(buddy, ".//md:link", md_ns())[[2]]
   expect_equal(xml2::xml_text(buddy_node2), "A")
   expect_equal(xml2::xml_attr(buddy_node2, "anchor"), "true")
-  
+
+})
+
+test_that("footnotes square brackets are not escaped", {
+  lines <- c(
+    "something[^1] nice", "anything[^ouch] good", "", "",
+    "[^1]: athing", "[^ouch]: anotherthing"
+    )
+  temp_file <- withr::local_tempfile()
+  writeLines(lines, temp_file)
+
+  expect_snapshot(cat(tinkr::yarn$new(temp_file, anchor_links = TRUE)$head()))
+  expect_snapshot(cat(tinkr::yarn$new(temp_file, anchor_links = FALSE)$head()))
 })

--- a/tests/testthat/test-anchor-links.R
+++ b/tests/testthat/test-anchor-links.R
@@ -63,7 +63,7 @@ test_that("singluar nodes can be added to the body", {
 test_that("footnotes square brackets are not escaped", {
   lines <- c(
     "something[^1] nice", "anything[^ouch] good", "", "",
-    "[^1]: athing", "[^ouch]: anotherthing"
+    "[^1]: a thing", "[^ouch]: another thing"
     )
   temp_file <- withr::local_tempfile()
   writeLines(lines, temp_file)


### PR DESCRIPTION
@zkamvar this is a follow-up to #92 

The difference is that the footnote text is more than one word.

I'm still exploring. :thinking: 