### PR TITLE
preserve bare links in markdown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## BUG FIX
 
+* Bare links in Markdown (e.g. `<https://example.com/one>`) are no longer
+  transformed to markdown-style links (e.g. 
+  `[https://example.com/one](https://example.com/one)`). (issue: #59; fix: #115)
 * Inline math with single characters will no longer cause an error (issue: #101,
   fix: #103, @maelle)
 * Special control characters are now filtered out before processing XML (issue:

--- a/inst/stylesheets/xml2md_gfm.xsl
+++ b/inst/stylesheets/xml2md_gfm.xsl
@@ -33,6 +33,16 @@
       <xsl:value-of select='string(.)'/>
     </xsl:template>
 
+    <!-- #59: preserve bare links -->
+    <xsl:template match="md:link[string(self::md:*)=@destination and @title='']">
+      <xsl:text>&#x3C;</xsl:text>
+      <xsl:call-template name="escape-text">
+          <xsl:with-param name="text" select="string(@destination)"/>
+          <xsl:with-param name="escape" select="'()'"/>
+      </xsl:call-template>
+      <xsl:text>&#x3E;</xsl:text>
+    </xsl:template>
+
     <xsl:template match="md:link[@rel] | md:image[@rel]">
       <xsl:if test="self::md:image">!</xsl:if>
       <xsl:text>[</xsl:text>

--- a/tests/testthat/_snaps/asis-nodes.md
+++ b/tests/testthat/_snaps/asis-nodes.md
@@ -50,7 +50,7 @@
       x = {-b \pm \sqrt{b^2-4ac} \over 2a}
       $$
       
-      Below is an example from [https://github.com/ropensci/tinkr/issues/38](https://github.com/ropensci/tinkr/issues/38)
+      Below is an example from <https://github.com/ropensci/tinkr/issues/38>
       $\frac{\sum _{i=N-n}^{N}Q_i} {\sum_{j=N-n}^{N}{(\frac{C_j+C_{j-1}}2)}}$
       
       ```latex

--- a/tests/testthat/_snaps/class-yarn.md
+++ b/tests/testthat/_snaps/class-yarn.md
@@ -16,7 +16,7 @@
       
       ## R Markdown
       
-      This is an ~~R Markdown document~~. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see [http://rmarkdown.rstudio.com](http://rmarkdown.rstudio.com).
+      This is an ~~R Markdown document~~. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
       
       When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
       

--- a/tests/testthat/_snaps/class-yarn/yarn.Rmd
+++ b/tests/testthat/_snaps/class-yarn/yarn.Rmd
@@ -11,7 +11,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ## R Markdown
 
-This is an ~~R Markdown document~~. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see [http://rmarkdown.rstudio.com](http://rmarkdown.rstudio.com).
+This is an ~~R Markdown document~~. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
 
 When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
 

--- a/tests/testthat/_snaps/to_md/new-code-chunk.Rmd
+++ b/tests/testthat/_snaps/to_md/new-code-chunk.Rmd
@@ -16,7 +16,7 @@ a <- 1:10
 
 ## R Markdown
 
-This is an ~~R Markdown document~~. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see [http://rmarkdown.rstudio.com](http://rmarkdown.rstudio.com).
+This is an ~~R Markdown document~~. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
 
 When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
 

--- a/tests/testthat/_snaps/to_md/to_md-works-for-Rmd.Rmd
+++ b/tests/testthat/_snaps/to_md/to_md-works-for-Rmd.Rmd
@@ -11,7 +11,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ## R Markdown
 
-This is an ~~R Markdown document~~. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see [http://rmarkdown.rstudio.com](http://rmarkdown.rstudio.com).
+This is an ~~R Markdown document~~. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
 
 When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
 

--- a/tests/testthat/test-to_md.R
+++ b/tests/testthat/test-to_md.R
@@ -174,3 +174,22 @@ test_that("links that start lines are not escaped", {
   expect_equal(actual, expected)
 
 })
+
+
+test_that("(#59) Bare links are not transformed to markdown links", {
+  input <- c(
+    "<https://example.com/one> and",
+    "[https://example.com/two](https://example.com/two \"with a title\") and",
+    "https://example.com/three",
+    ""
+  )
+  tmp <- withr::local_tempfile()
+  writeLines(input, tmp)
+  expected <- input
+  expected[3] <- paste0("<", input[3], ">")
+  expected <- paste(expected, collapse = "\n")
+  xml <- to_xml(tmp)
+  md <- to_md(xml)
+  expect_identical(expected, md)
+})
+


### PR DESCRIPTION
This preserves bare links in markdown. The XML version of markdown does not differentiate between `[link.url](link.url)` and `<link.url>`, which leads to a transformation of the latter into the former during a roundtrip.

This will fix that issue to the best of our ability by forcing all links that have the same text and destination to be rendered as `<link>`:

``` r
f <- textConnection("[good link](https://example.com)\nbare link: https://example.com\nbracketed link: <https://example.com>") 
y <- tinkr::yarn$new(f); close(f) 
y$show()    
#> [good link](https://example.com)
#> bare link: <https://example.com>
#> bracketed link: <https://example.com>
```

<sup>Created on 2024-05-22 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

This will fix #59