### PR TITLE
allow for French-style dollar signs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,7 +39,8 @@
 * Documents with no trailing newline will no longer throw a warning (issue: #65;
   fix: #114, @zkamvar)
 * Documents with dollar signs but no math will no longer fail with the
-  `$protect_math()` method (issue: #121, @maelle; fix: #122, @zkamvar).
+  `$protect_math()` method
+  (issue: #121, #124 @maelle; fix: #122, #125 @zkamvar)
 
 ## MISC
 

--- a/R/asis-nodes.R
+++ b/R/asis-nodes.R
@@ -144,9 +144,9 @@ protect_inline_math <- function(body, ns) {
     # an error.
     le <- length(bmath[endless])
     lh <- length(bmath[headless])
-    # 2024-10-10: if the number of headless tags is zero, then we are dealing
-    # with currency. See issue #121 
-    if (lh == 0) {
+    # 2024-10-10: if the number of headless OR endless tags is zero, then we
+    # are dealing with currency. See issue #121 and #124
+    if (lh == 0 || le == 0) {
       return(copy_xml(body))
     }
     if (le != lh) {

--- a/tests/testthat/test-asis-nodes.R
+++ b/tests/testthat/test-asis-nodes.R
@@ -7,6 +7,15 @@ test_that("(#121) single dollar lines dont throw errors", {
   expect_equal(actual, expected)
 })
 
+test_that("(#124) french dollar lines dont throw errors", {
+  expected <- "I've only got 2$ in the bank. Feels bad, man. Feels bad to not have 2 $\n"
+  math <- commonmark::markdown_xml(expected)
+  txt <- xml2::read_xml(math)
+  expect_no_error(protxt <- protect_inline_math(txt, md_ns()))
+  actual <- to_md(list(yaml = NULL, body = protxt))
+  expect_equal(actual, expected)
+})
+
 test_that("mal-formed inline math throws an informative error", {
   patherr  <- system.file("extdata", "basic-math.md", package = "tinkr")
   me <- yarn$new(patherr, sourcepos = TRUE)


### PR DESCRIPTION
This allows trailing dollar signs to pass check.

Note that this will still cause a ruckus if there is a mix of both styles.

This will fix #124
