### PR TITLE
Use rOpenSci ROR link as per CRAN request

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Authors@R:
              comment = "Nick Wellnhofer wrote the XSLT stylesheet."),
       person(given = "rOpenSci",
              role = "fnd",
-             comment = "https://ropensci.org/"),
+             comment = c(ROR = "019jywm96")),
       person(given = "Peter",
              family = "Daengeli",
              role = "ctb"))


### PR DESCRIPTION
CRAN has asked if we can link the ropensci entry to our ROR profile.