### PR TITLE
fix: better regex for alt text in curly

### DIFF
--- a/R/attr-nodes.R
+++ b/R/attr-nodes.R
@@ -30,7 +30,7 @@ digest_curly <- function(curly, ns) {
   for (curl in curlies) {
     attributes <- "curly='true'"
 
-    alt_fragment <- regmatches(curl, gregexpr("alt=['\"].*?\1", curl))[[1]]
+    alt_fragment <- regmatches(curl, gregexpr("alt=(['\"]).*?\\1", curl))[[1]]
     if (length(alt_fragment) > 0) {
       alt_text <- sub("^alt=", "", alt_fragment)
       attributes <- sprintf("%s alt=%s", attributes, alt_text)

--- a/R/attr-nodes.R
+++ b/R/attr-nodes.R
@@ -30,7 +30,7 @@ digest_curly <- function(curly, ns) {
   for (curl in curlies) {
     attributes <- "curly='true'"
 
-    alt_fragment <- regmatches(curl, gregexpr("alt=['\"].*?['\"]", curl))[[1]]
+    alt_fragment <- regmatches(curl, gregexpr("alt=['\"].*?\1", curl))[[1]]
     if (length(alt_fragment) > 0) {
       alt_text <- sub("^alt=", "", alt_fragment)
       attributes <- sprintf("%s alt=%s", attributes, alt_text)

--- a/inst/extdata/basic-curly.md
+++ b/inst/extdata/basic-curly.md
@@ -13,7 +13,7 @@ Images that use pandoc style will have curlies with content that should be trans
 ![a pretty kitten](https://placekitten.com/200/300){#kitteh alt='a picture of a kitten'}
 
 ![a pretty puppy](https://placedog.net/200/300){#dog alt="a picture 
-of a dog"}
+of Mickey's dog"}
 
 [a span with attributes]{.span-with-attributes 
 style='color: red;'}

--- a/tests/testthat/_snaps/attr-nodes.md
+++ b/tests/testthat/_snaps/attr-nodes.md
@@ -29,7 +29,7 @@
             <text sourcepos="10:3-10:17" xml:space="preserve">a pretty kitten</text>
           </image>
           <text sourcepos="10:52-10:88" xml:space="preserve"/>
-          <text curly="true">{#kitteh alt='a picture of a kitten'}</text>
+          <text curly="true" alt="a picture of a kitten">{#kitteh alt='a picture of a kitten'}</text>
           <text/>
         </paragraph>
         <paragraph sourcepos="12:1-13:17">
@@ -37,7 +37,7 @@
             <text sourcepos="12:3-12:16" xml:space="preserve">a pretty puppy</text>
           </image>
           <text sourcepos="12:48-12:68" xml:space="preserve"/>
-          <text curly="true">{#dog alt="a picture
+          <text curly="true" alt="a picture of Mickey's dog">{#dog alt="a picture
       of Mickey's dog"}</text>
           <text/>
           <softbreak/>

--- a/tests/testthat/_snaps/attr-nodes.md
+++ b/tests/testthat/_snaps/attr-nodes.md
@@ -29,16 +29,16 @@
             <text sourcepos="10:3-10:17" xml:space="preserve">a pretty kitten</text>
           </image>
           <text sourcepos="10:52-10:88" xml:space="preserve"/>
-          <text curly="true" alt="a picture of a kitten">{#kitteh alt='a picture of a kitten'}</text>
+          <text curly="true">{#kitteh alt='a picture of a kitten'}</text>
           <text/>
         </paragraph>
-        <paragraph sourcepos="12:1-13:10">
+        <paragraph sourcepos="12:1-13:17">
           <image sourcepos="12:1-12:47" destination="https://placedog.net/200/300" title="">
             <text sourcepos="12:3-12:16" xml:space="preserve">a pretty puppy</text>
           </image>
           <text sourcepos="12:48-12:68" xml:space="preserve"/>
-          <text curly="true" alt="a picture of a dog">{#dog alt="a picture
-      of a dog"}</text>
+          <text curly="true">{#dog alt="a picture
+      of Mickey's dog"}</text>
           <text/>
           <softbreak/>
         </paragraph>

--- a/tests/testthat/_snaps/attr-nodes/yarn.md
+++ b/tests/testthat/_snaps/attr-nodes/yarn.md
@@ -13,7 +13,7 @@ Images that use pandoc style will have curlies with content that should be trans
 ![a pretty kitten](https://placekitten.com/200/300){#kitteh alt='a picture of a kitten'}
 
 ![a pretty puppy](https://placedog.net/200/300){#dog alt="a picture
-of a dog"}
+of Mickey's dog"}
 
 
 [a span with attributes]{.span-with-attributes

--- a/tests/testthat/_snaps/class-yarn.md
+++ b/tests/testthat/_snaps/class-yarn.md
@@ -135,7 +135,7 @@
       writeLines(old)
     Output
       ![a pretty puppy](https://placedog.net/200/300){#dog alt="a picture
-      of a dog"}
+      of Mickey's dog"}
       
       \[a span with attributes\]{.span-with-attributes
       style='color: red;'}
@@ -147,7 +147,7 @@
       writeLines(new)
     Output
       ![a pretty puppy](https://placedog.net/200/300){#dog alt="a picture
-      of a dog"}
+      of Mickey's dog"}
       
       [a span with attributes]{.span-with-attributes
       style='color: red;'}


### PR DESCRIPTION
Fix https://github.com/ropensci-review-tools/babeldown/issues/104

I used Claude to explain and fix the regex, all the rest is mine.